### PR TITLE
Fix for issue #7

### DIFF
--- a/nhlscrapi/scrapr/teamnameparser.py
+++ b/nhlscrapi/scrapr/teamnameparser.py
@@ -20,16 +20,16 @@ def team_abbr_parser(abr):
 
 
 def team_name_parser(name):
-  
-  # give proper capitalization
-  ns = ' '.join(s[:1].upper() + s[1:] for s in name.lower().split(' '))
+  # give proper capitalization, translate to expected team name
+  # WASHINGTON CAPITALS -> Washington Capitals
+  # ST. LOUIS BLUES -> St Louis Blues
+  ns = ' '.join(s[:1].upper() + s[1:] for s in name.lower().replace('.','').split(' '))
   
   try:
-    return ABB.keys()[ABB.values().index(ns)]
+    return ABB.keys()[ABB.values().index(ns)] #Reverse lookup, by value.
   except:
     #print 'UNKNOWN TEAM NAME: %s' % name
     pass
   
   return name
-  
   


### PR DESCRIPTION
Fixed issue where period in team name (St. Louis Blues) caused lookup of
team abbreviation to fail. Since no team name values have a period, it
is safe to just remove all periods.