### PR TITLE
Fix for issue #13 (leading space in player first name)

### DIFF
--- a/nhlscrapi/scrapr/eventsummrep.py
+++ b/nhlscrapi/scrapr/eventsummrep.py
@@ -216,7 +216,7 @@ class EventSummRep(ReportLoader):
             dat['pos'] = rec[1]
             
             last, first = rec[2].split(',')
-            dat['name'] = { 'first': first, 'last': last }
+            dat['name'] = { 'first': first.strip(), 'last': last.strip() }
             
             dat['shifts'] = to_int(rec[10],0)
             


### PR DESCRIPTION
See summary. Names were split just on the comma from "LAST, FIRST" so
the middle space was kept. Instead of splitting on ", " (comma space) I
feel like this is a bit safer, in case there's a typo sometime down the
road.